### PR TITLE
Align GitHub workflows with rest of GradleX

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,12 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v4.6.0
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 11
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3.5.0
+        uses: gradle/actions/setup-gradle@v4
       - run: "./gradlew build"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,5 +1,11 @@
-name: Build Plugin
-on: [ push, pull_request ]
+name: "CI Build"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   gradle-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,8 +1,0 @@
-name: Validate Gradle Wrapper
-on: [ push, pull_request ]
-jobs:
-  validation:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: gradle/wrapper-validation-action@v3.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v4.6.0
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 11
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3.5.0
+        uses: gradle/actions/setup-gradle@v4
       - run: "./gradlew :publishPlugin --no-configuration-cache"
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}


### PR DESCRIPTION
- Use setup-gradle action
- Drop gradle-wrapper-validation because it's included in setup-gradle
- Pin actions to the latest major only
