### PR TITLE
Port dependency constraints for checkstyle from build-parameters plugin

### DIFF
--- a/src/main/java/org/gradlex/conventions/pluginpublish/PluginPublishConventionsPlugin.java
+++ b/src/main/java/org/gradlex/conventions/pluginpublish/PluginPublishConventionsPlugin.java
@@ -71,5 +71,9 @@ public abstract class PluginPublishConventionsPlugin implements Plugin<Project> 
         });
 
         checkstyle.getConfigDirectory().set(project.getLayout().getProjectDirectory().dir("gradle/checkstyle"));
+        project.getDependencies().getConstraints()
+            .add("checkstyle", "com.google.guava:guava:33.4.8-jre", c -> c.because("CVE-2023-2976, CVE-2020-8908"));
+        project.getDependencies().getConstraints()
+            .add("checkstyle", "commons-beanutils:commons-beanutils:1.11.0", c -> c.because("CVE-2025-48734"));
     }
 }


### PR DESCRIPTION
Most of our plugin have multiple GitHub security alerts reported due to
vulnerable transitive dependencies on the build classpath. There are two
sources for these:

1. transitive dependencies of the checkstyle plugin
2. transitive dependencies of exemplar

Since we apply and configure checkstyle in this convention plugin, it
makes sense to fix CVEs here as well by upgrading the affected
dependencies.

So this commit basically ports the configuration from
https://github.com/gradlex-org/build-parameters/blob/0315507362b027bab91c797ad2bdbfc4debf165b/build.gradle.kts#L16-L21
to this plugin which will resolve security alerts such as
https://github.com/gradlex-org/maven-plugin-development/security/dependabot/23.
